### PR TITLE
Update git2r package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Rperform helps R package developers keep track of the quantitative
     metrics of their packages over various development versions.
 BugReports: https://github.com/analyticalmonk/Rperform/issues
 Imports:
-    git2r (<= 0.21.0),
+    git2r (>= 0.30.1),
     ggplot2 (>= 1.0.1),
     testthat (>= 0.10.0),
     devtools (>= 1.8.0),

--- a/R/branch_metrics.R
+++ b/R/branch_metrics.R
@@ -56,7 +56,7 @@ time_branch <- function(test_path, branch = "master", num_commits = 5) {
   
   # Git operations
   target <- git2r::repository("./")
-  origin_state <- git2r::head(target)
+  origin_state <- git2r::repository_head(target)
   git2r::checkout(target, branch)
   on.exit(expr = git2r::checkout(origin_state))
   
@@ -194,7 +194,7 @@ compare_branchm <- function(test_path, branch1, branch2 = "master") {
   stopifnot(length(branch2) == 1)
   
   target <- git2r::repository("./")
-  original_state <- git2r::head(target)
+  original_state <- git2r::repository_head(target)
   same_commit <- .common_commit(branch1 = branch1, branch2 = branch2)
   #                  same_commit
   # ---------------------------------------------
@@ -239,7 +239,7 @@ compare_branchm <- function(test_path, branch1, branch2 = "master") {
   target1 <- git2r::repository(file.path("./"))
   # If branch1 is specified, check out to it and obtain commit list
   if (!is.null(branch1)) {
-    original_state1 <- git2r::head(target1)
+    original_state1 <- git2r::repository_head(target1)
     git2r::checkout(object = target1, branch = branch1)
   }
   commitlist1 <- git2r::commits(target1)
@@ -256,7 +256,7 @@ compare_branchm <- function(test_path, branch1, branch2 = "master") {
   target2 <- git2r::repository(file.path("./"))
   # If branch2 is specified, check out to it and obtain commit list
   if (!is.null(branch2)) {
-    original_state2 <- git2r::head(target2)
+    original_state2 <- git2r::repository_head(target2)
     git2r::checkout(object = target2, branch = branch2) 
   }
   commitlist2 <- git2r::commits(target2)

--- a/R/git_help.R
+++ b/R/git_help.R
@@ -13,7 +13,7 @@
 get_sha <- function(commit_val) {
   stopifnot(git2r::is_commit(commit_val))
   
-  attr(commit_val, which = "sha")  
+   commit_val$sha
 }
 
 ##  -----------------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ get_sha <- function(commit_val) {
 get_datetime <- function(commit_val) {
   stopifnot(git2r::is_commit(commit_val))
   
-  methods::as((commit_val@committer@when), "POSIXct")
+  as.POSIXct(git2r::when(commit_val$author$when))
 }
 
 ##  -----------------------------------------------------------------------------------------
@@ -49,7 +49,7 @@ get_datetime <- function(commit_val) {
 get_msg <- function(commit_val) {
   stopifnot(git2r::is_commit(commit_val))
   
-  base::substr(commit_val@summary, start = 1, stop = 15)  
+  base::substr(commit_val[[4]], start = 1, stop = 15)  
 }
 
 ##  -----------------------------------------------------------------------------------------
@@ -65,7 +65,8 @@ get_msg <- function(commit_val) {
 
 get_branch <- function(dir_path = "./") {
   repo <- git2r::repository(dir_path)
-  git2r::head(repo)@name
+  head <- git2r::repository_head(repo)
+  head[[1]]
 }
 
 ##  -----------------------------------------------------------------------------------------

--- a/R/plot_metrics.R
+++ b/R/plot_metrics.R
@@ -63,7 +63,7 @@ utils::globalVariables(c("metric_val", "test_name"))
 #'
 
 plot_metrics <- function(test_path, metric, num_commits = 5, save_data = FALSE, save_plots = FALSE,
-                         interactive = FALSE) {
+                         interactive = FALSE){                     
   stopifnot(is.character(test_path))
   stopifnot(length(test_path) == 1)
   stopifnot(is.character(metric))
@@ -75,12 +75,12 @@ plot_metrics <- function(test_path, metric, num_commits = 5, save_data = FALSE, 
   stopifnot(is.logical(save_plots))
   stopifnot(length(save_plots) == 1)
   floor(num_commits)
-  
+
   if (metric == "time") {
     if (interactive) {
       temp_out <- capture.output(.plot_interactive_time(test_path, num_commits, save_data, save_plots))
     } else {
-      temp_out <- capture.output(.plot_time(test_path, num_commits, save_data, save_plots))
+       temp_out <- capture.output(.plot_time(test_path, num_commits, save_data, save_plots))      
     }
   }
   else if (metric == "memory") {
@@ -221,10 +221,8 @@ plot_metrics <- function(test_path, metric, num_commits = 5, save_data = FALSE, 
 
 
 .plot_time <- function(test_path, num_commits, save_data, save_plots) {
-  
   # Obtain the metrics data
   suppressMessages(time_data <- time_compare(test_path, num_commits))
-  
   # Store the metrics data if save_data is TRUE
   if (save_data){
     

--- a/R/repo_metrics.R
+++ b/R/repo_metrics.R
@@ -55,9 +55,10 @@ list_commits <- function(path = "./", num_commits = 20){
   date_list <- list()
   
   for (i in 1:num_commits) {
-    com <- attr(commit_list[[i]], which = "sha")
-    msg <- attr(commit_list[[i]], which = "summary")
-    com_date <- as(commit_list[[i]]@committer@when, "character")
+    com <- commit_list[[i]]$sha
+    msg <- commit_list[[i]]$summary    
+    com_date <- commit_list[[i]]$author$when
+  
     sha_list[i] <- com
     msg_list[i] <- msg
     date_list[i] <- com_date
@@ -152,7 +153,7 @@ time_commit <- function(test_path, test_commit) {
   target <- git2r::repository("./")
 # Reverting to the current branch on exit from the function
 ######################################################################  
-  original_state <- git2r::head(target)
+  original_state <- git2r::repository_head(target)
   git2r::checkout(test_commit)
   on.exit(expr = git2r::checkout(original_state))
 ######################################################################
@@ -229,7 +230,7 @@ time_commit <- function(test_path, test_commit) {
 
     time_df <- data.frame(test_name, metric_name = "runtime (in seconds)", status, 
                           metric_val = seconds, message = msg_val, 
-                          sha = sha_val, date_time = commit_dtime)
+                          sha = sha_val, date_time = commit_dtime)                     
     test_results[[test_name]] <<- time_df
   }
 
@@ -415,7 +416,7 @@ mem_commit <- function(test_path, test_commit) {
   
   ## Git operations
   target <- git2r::repository("./")
-  original_state <- git2r::head(target)
+  original_state <- git2r::repository_head(target)
   git2r::checkout(test_commit)
   on.exit(expr = git2r::checkout(original_state))
   test_results <- list()


### PR DESCRIPTION
This PR focuses on updating the [git2r](https://github.com/ropensci/git2r) package to support the latest features and improvements.
More specifically `git2r (>= 0.30.1)`
However, updating the package came with a minor hurdle.
The package has transitioned from supporting S4 objects to S3 objects.
Hence, it has made some of the functions used with `git2r (<= 0.21.0)` obsolete.
Therefore, I have updated and tested all the git2r functions that we use to support S3 objects.