### PR TITLE
Add more functionalities to GitHub Action

### DIFF
--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -102,50 +102,43 @@ runs:
           const initTime = Number(fs.readFileSync('./rperform-results/TIME_NO'));
           
           var pr_files = readFiles('./rperform-results');
-          const commentFiles = [];
-
+          var report = "";
            pr_files.forEach(file => {
             const split1 = file.split("_");
             const split2 = split1[1].split("/");
             const scriptTime =  Number(split2[0]);
-
             if(scriptTime >= initTime){
-              commentFiles.push(file);
+              const fileBody = fs.readFileSync(file).toString();
+              report += fileBody;
             }
           });
-   
-          for (var i = 0; i < commentFiles.length; i++) {
-               var body = fs.readFileSync(commentFiles[i]).toString();
-               await github.rest.issues.createComment({
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 issue_number: prNumber,
-                 body: body
-               });
-          }
-    - uses: actions/github-script@v5
-      if: always()
-      with:
-        script: |
-          let url = '${{ github.event.workflow_run.html_url }}'
-          let any_failed = ${{ steps.comment.outcome == 'failure' || steps.download.outcome == 'failure' }}
-          let state = 'success'
-          let description = 'Commenting succeeded!'
-
-          if(${{ github.event.workflow_run.conclusion == 'failure'}} || any_failed) {
-            state = 'failure'
-            description = 'Commenting failed!'
-            if(any_failed) {
-              url = "https://github.com/${{github.repository}}/actions/runs/" + 
-                    "${{ github.run_id }}"
+            // Get the list of all the comments on the PR
+            const response = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+            })
+            const comments = response.data;
+            // Get the comment made by the action
+            const commentIdentifier = "<!-- Rperform-action comment-->"
+            const actionComment = comments.find(comment => comment.body.includes(commentIdentifier))
+            const newCommentBody = `${commentIdentifier}\n${report}`
+            // Print the comment made by the action
+            console.log(actionComment);
+            
+            // If actionComment exists, update it otherwise create a new comment
+            if (actionComment) {
+                await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: actionComment.id,
+                    body: newCommentBody
+                })
+            } else {
+                await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: newCommentBody
+                })
             }
-          }
-          github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: '${{ github.event.workflow_run.head_sha}}',
-            state: state,
-            target_url: url,
-            description: description,
-            context: 'rperform comment'
-          })

--- a/actions/comment/action.yaml
+++ b/actions/comment/action.yaml
@@ -122,7 +122,10 @@ runs:
             // Get the comment made by the action
             const commentIdentifier = "<!-- Rperform-action comment-->"
             const actionComment = comments.find(comment => comment.body.includes(commentIdentifier))
-            const newCommentBody = `${commentIdentifier}\n${report}`
+
+            const defaultFooter = "\nFurther explanation regarding interpretation and methodology can be found in the [documentation](https://github.com/analyticalmonk/Rperform#readme)";
+
+            const newCommentBody = `${commentIdentifier}\n${report}\n${defaultFooter}`;
             // Print the comment made by the action
             console.log(actionComment);
             

--- a/actions/receive/action.yaml
+++ b/actions/receive/action.yaml
@@ -45,16 +45,7 @@ runs:
           any::gert
           any::glue
           github::EngineerDanny/Rperform${{ inputs.rperform_ref}}
-          
-    - name: Remove global installation
-      run: |
-        pkg <- unlist(read.dcf('DESCRIPTION')[, 'Package'])
-        if (pkg %in% rownames(installed.packages())) {
-          remove.packages(pkg)
-          cat('removed package ', pkg, '.', sep = "")
-        }
-      shell: Rscript {0}
-
+  
     - name: "Save Current Time Integer"
       id: "set-time"
       uses: actions/github-script@v6
@@ -77,9 +68,7 @@ runs:
       run: |
         echo $PULL_REQUEST_NUMBER > ./rperform/results/PR_NO
         echo "${{steps.set-time.outputs.result}}"  > ./rperform/results/TIME_NO
-
     - uses: actions/upload-artifact@v2
       with:
         name: pr
         path: rperform/results/
-

--- a/inst/footer.R
+++ b/inst/footer.R
@@ -1,9 +1,7 @@
 
 # You can modify the PR comment footer here. You can use github markdown e.g.
 # emojis like :tada:.
-# See `?Rperform::pr_comment`
 link <- "https://github.com/analyticalmonk/Rperform#readme"
 glue::glue(
-  "\n\nFurther explanation regarding interpretation and",
-  " methodology can be found in the [documentation]({link})."
+  "\n--------------------------------------------------\n"
 )


### PR DESCRIPTION
This PR addresses the problem of numerous comments given by the Github bot when there are several pushes to a PR.
With the new changes, when a PR is opened and the Github bot comments, the subsequent comment will update the old one. This eliminates the need to scroll down just to search for the latest test results.